### PR TITLE
make copy-certs work with namespaces other than kube-public

### DIFF
--- a/quick-install/copy-certs-tmpl.yaml
+++ b/quick-install/copy-certs-tmpl.yaml
@@ -9,7 +9,6 @@
 kind: Job
 apiVersion: batch/v1
 metadata:
-  namespace: kube-public
   name: copy-certs-{{.metadata.uid}}
 spec:
   template:
@@ -20,6 +19,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: copy-certs-{{.metadata.uid}}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           image: containersol/trow:copy-certs
           imagePullPolicy: Always
           volumeMounts:

--- a/quick-install/copy-certs.sh
+++ b/quick-install/copy-certs.sh
@@ -6,17 +6,22 @@ IFS=$'\n\t'
 echo
 echo "Copying certs to nodes"
 
+NAMESPACE=kube-public
+if [ -n $1 ]
+then
+	NAMESPACE=$1
+
 #delete any old jobs
-for job in $(kubectl get jobs -n kube-public -o go-template --template '{{range .items}}{{.metadata.name}}
+for job in $(kubectl get jobs -n $NAMESPACE -o go-template --template '{{range .items}}{{.metadata.name}}
 
 {{end}}') # blank line is important
 do
   if [[ $job = copy-certs* ]]; then
-    kubectl delete -n kube-public job "$job"
+    kubectl delete -n $NAMESPACE job "$job"
   fi
 done
 tmp_file=$(mktemp)
 kubectl get nodes -o go-template-file --template copy-certs-tmpl.yaml > "$tmp_file"
-kubectl create -f "$tmp_file"
+kubectl create -f "$tmp_file" -n $NAMESPACE
 rm "$tmp_file"
 

--- a/quick-install/copy-certs/Dockerfile
+++ b/quick-install/copy-certs/Dockerfile
@@ -4,11 +4,6 @@ RUN apt-get update && apt-get install -y \
       ed curl \
     && rm -rf /var/lib/apt/lists/*
 
-# This should download the latest stable version of kubectl
-# It's not great from a provenance pov, but it's basically the same as the
-# official instructions
-RUN curl -o /usr/local/bin/kubectl -sSL https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-RUN chmod +x /usr/local/bin/kubectl 
 COPY job.sh /
 RUN chmod +x /job.sh
 ENTRYPOINT /job.sh

--- a/quick-install/copy-certs/job.sh
+++ b/quick-install/copy-certs/job.sh
@@ -8,8 +8,7 @@ registry_host_port="${registry_host}:${registry_port}"
 
 mkdir --parents "/etc/docker/certs.d/$registry_host_port/"
 echo "copying certs"
-kubectl get configmap trow-ca-cert -n $POD_NAMESPACE -o jsonpath='{.data.cert}' \
-    > "/etc/docker/certs.d/$registry_host_port/ca.crt"
+cp /run/secrets/kubernetes.io/serviceaccount/ca.crt /etc/docker/certs.d/$registry_host_port/
 echo "Successfully copied certs"
 
 echo "Adding entry to /etc/hosts"

--- a/quick-install/copy-certs/job.sh
+++ b/quick-install/copy-certs/job.sh
@@ -2,13 +2,13 @@
 set -e
 set -o pipefail
 
-registry_host="trow.kube-public"
+registry_host="trow.${POD_NAMESPACE}"
 registry_port="31000"
 registry_host_port="${registry_host}:${registry_port}"
 
 mkdir --parents "/etc/docker/certs.d/$registry_host_port/"
 echo "copying certs"
-kubectl get configmap trow-ca-cert -n kube-public -o jsonpath='{.data.cert}' \
+kubectl get configmap trow-ca-cert -n $POD_NAMESPACE -o jsonpath='{.data.cert}' \
     > "/etc/docker/certs.d/$registry_host_port/ca.crt"
 echo "Successfully copied certs"
 


### PR DESCRIPTION
continuing my efforts to ensure that trow can work in namespaces other than kube-public, this enables the copy-certs containers to work