### PR TITLE
more changes to namespace usage

### DIFF
--- a/quick-install/configure-host.sh
+++ b/quick-install/configure-host.sh
@@ -2,7 +2,13 @@
 set -eo pipefail
 unset CDPATH
 
-registry_host="trow.kube-public"
+namespace='kube-public'
+if [ -z $1 ]
+then
+	namespace=$1
+fi
+
+registry_host="trow.${namespace}"
 registry_port="31000"
 registry_host_port="${registry_host}:${registry_port}"
 add_host_ip=""
@@ -104,8 +110,8 @@ else #On linux
 fi
 
 if [[ "$1" = "--add-hosts" ]]; then
-  echo "Adding entry to /etc/hosts for trow.kube-public" 
+  echo "Adding entry to /etc/hosts for trow.${namespace}" 
   get_ip_from_k8s
-  add_host_name="trow.kube-public"
+  add_host_name="trow.${namespace}"
   add_to_etc_hosts
 fi

--- a/quick-install/install-trow.sh
+++ b/quick-install/install-trow.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+namespace='kube-public'
+if [ -z $1 ]
+then
+	namespace=$1
+fi
+trow_dir=$(dirname $0)
+
+tmp_file=$(mktemp)
+sed "s/{{namespace}}/${namespace}/" ${trow_dir}/trow-tmpl.yaml > $tmp_file
+
+kubelet -n $namespace apply -f $tmp_file
+

--- a/quick-install/trow.yaml
+++ b/quick-install/trow.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: kube-public
   name: trow
   labels:
     app: trow
@@ -9,7 +8,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  namespace: kube-public
   name: trow
   labels:
     app: trow
@@ -27,8 +25,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  namespace: kube-public
-  name: trow
+  name: '{{namespace}}:trow'
   labels:
     app: trow
 rules:
@@ -45,7 +42,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  namespace: kube-public
   name: trow
   labels:
     app: trow
@@ -56,13 +52,12 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: trow
-  namespace: kube-public
+  namespace: {{namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  namespace: kube-public
-  name: trow
+  name: '{{namespace}}:trow'
   labels:
     app: trow
 roleRef:
@@ -72,13 +67,12 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: trow
-  namespace: kube-public
+  namespace: {{namespace}}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: trow-deploy
-  namespace: kube-public
 spec:
   selector:
     matchLabels:
@@ -92,7 +86,7 @@ spec:
       containers:
       - name: trow-pod
         image: containersol/trow:default
-        args: ["-n", "trow:31000 trow.kube-public:31000", "-c", "/certs/domain.crt"]
+        args: ["-n", "trow:31000 trow.{{namespace}}:31000", "-c", "/certs/domain.crt"]
         imagePullPolicy: Always
         ports:
         - containerPort: 8443
@@ -137,7 +131,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: trow
-  namespace: kube-public
 spec:
   selector:
     app: trow

--- a/quick-install/validate.sh
+++ b/quick-install/validate.sh
@@ -9,8 +9,15 @@ echo "By default, only images in Trow and official Kubernetes images will be
 allowed"
 echo
 
-cabundle=$(kubectl get configmap trow-ca-cert -n kube-public -o jsonpath='{.data.cert}' | openssl base64 | tr -d '\n')
+namespace='kube-public'
+if [ -z $1 ]
+then
+	namespace=$1
+fi
+
+cabundle=$(kubectl get configmap trow-ca-cert -n $namespace -o jsonpath='{.data.cert}' | openssl base64 | tr -d '\n')
 #Really not happy about use of sed here
 #Can we use go-template now?
-sed "s/{{cabundle}}/${cabundle}/" validate-tmpl.yaml > validate.yaml
-kubectl apply -f validate.yaml
+tmp_file=$(mktemp)
+sed "s/{{cabundle}}/${cabundle}; s/{{namespace}}/${namespace}/" validate-tmpl.yaml > $tmp_file
+kubectl apply -f $tmp_file


### PR DESCRIPTION
after this, the only thing that isn't caught is the master install.sh
    
this adds templating to trow.yaml (unsure why trow-gke.yaml is needed, as I'm using trow.yaml on gke without a problem)
    
this adds an install-trow.sh that uses sed to replace {{namespace}} with proper namespace

