### PR TITLE
Typo error in file - copy-certs-tmpl

### DIFF
--- a/quick-install/copy-certs-tmpl.yaml
+++ b/quick-install/copy-certs-tmpl.yaml
@@ -2,7 +2,7 @@
   {{- $schedulable := true }}
   {{- range .spec.taints}}
     {{- if eq .effect "NoSchedule"}}
-      {{- $schedulable = false }}
+      {{- $schedulable := false }}
     {{- end}}
   {{- end}}
   {{- if $schedulable }}


### PR DESCRIPTION
Typo error in the file (copy-certs-tmpl.YAML) causing the install script to fail. fixed the typo and now installation is successfull.