### PR TITLE
Use StatefulSet for installs.

### DIFF
--- a/install/INSTALL.md
+++ b/install/INSTALL.md
@@ -1,7 +1,7 @@
 Standard Kubernetes Install
 ===========================
 
-At its heart, Trow is just a single deploy that needs to be exposed through a service. The main
+At its heart, Trow is just a StatefulSet that needs to be exposed through a service. The main
 complication is getting TLS configured correctly. The developer or quick install uses a
 cluster-signed cert that is used by Trow itself and copies the CA certificate to all nodes and
 clients. The standard install runs Trow behind a TLS-terminating ingress. The TLS cert can be

--- a/install/base/kustomization.yaml
+++ b/install/base/kustomization.yaml
@@ -3,19 +3,19 @@ kind: Kustomization
 
 namespace: trow
 
-# This will bring up the main trow pod, a persistent volume for data, and a service that routes
-# to it. 
+# This will bring up the main trow pod as StatefulService, a persistent volume for data, and a
+# service that routes to it. 
 #
 # A working install will require an ingress forwarding a (sub)domain you control to this service.
 # This install assumes the ingress terminates TLS; internally Trow is running over http only.
 #
 # The overlay directories include examples of how to provision ingress on various types of
 # Kubernetes cluster.
-#
+
+
 resources: 
-- deploy.yaml 
+- stateful-set.yaml 
 - service.yaml 
-- pvc.yaml
 
 #- validate.yaml # Enable for validation webhook
   
@@ -23,15 +23,17 @@ images:
 - name: containersol/trow
   newTag: "0.2"
 
-# The following patches update the domain name in the trow argument and validator without editing the yaml. 
-# Create your own version of the patch file with your domain name and reference in your overlay as
-# below:
-#
+# The following patches update the domain name in the trow argument and validator without editing
+# the YAML directly.  
+# Create your own version of the patch file with your domain name and reference in your
+# overlay as below:
+
+
 patchesJson6902:
 #    - path: patch-trow-arg.yaml
 #      target:
-#        kind: Deployment
-#        name: trow-deploy
+#        kind: StatefulSet
+#        name: trow-set
 #        group: apps
 #        version: v1
 #

--- a/install/base/kustomization.yaml
+++ b/install/base/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 namespace: trow
 
-# This will bring up the main trow pod as StatefulService, a persistent volume for data, and a
-# service that routes to it. 
+# This will start Trow in a StatefulSet along with a persistent volume for data and a service that
+# routes to it. 
 #
 # A working install will require an ingress forwarding a (sub)domain you control to this service.
 # This install assumes the ingress terminates TLS; internally Trow is running over http only.

--- a/install/base/stateful-set.yaml
+++ b/install/base/stateful-set.yaml
@@ -1,11 +1,12 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: trow-deploy
+  name: trow-set
 spec:
   selector:
     matchLabels:
       app: trow
+  serviceName: trow
   template:
     metadata:
       labels:
@@ -32,16 +33,21 @@ spec:
           mountPath: /etc/trow
           readOnly: true
       volumes:
-        - name: data-vol
-          persistentVolumeClaim:
-              claimName: trow-data-claim
         - name: trow-pass
           secret:
-              secretName: trow-pass
-              items:
-                  - key: pass
-                    path: pass
+            secretName: trow-pass
+            items:
+              - key: pass
+                path: pass
       securityContext:             
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+  volumeClaimTemplates:
+    - metadata:
+        name: data-vol
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 20Gi

--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -29,8 +29,8 @@ patchesJson6902:
       version: v1beta1
   - path: patch-trow-arg.yaml
     target:
-      kind: Deployment
-      name: trow-deploy
+      kind: StatefulSet
+      name: trow-set
       group: apps
       version: v1
 


### PR DESCRIPTION
Trow should be using a StatefulSet instead of a deployment for installs. This fixes the standard installation instructions to use a StatefulSet.

Quick Install is less important, but we should also look into updating.