### PR TITLE
Pin to specific nightly again.

### DIFF
--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -2,8 +2,8 @@
 #This can be a lot faster than compiling directly on slow hw.
 
 #Not a big fan of using nightly, but such is our lot currently
-FROM --platform=linux/amd64 rust:latest as builder
-RUN rustup update nightly && rustup default nightly && \
+FROM --platform=linux/arm64 rust:latest as builder
+RUN rustup update nightly-2020-05-15 && rustup default nightly-2020-05-15 && \
     rustup component add rustfmt && rustup target install aarch64-unknown-linux-gnu && \
     rustup toolchain install nightly-aarch64-unknown-linux-gnu
 RUN apt-get update && apt-get install -y unzip gcc-aarch64-linux-gnu

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -4,7 +4,7 @@
 #Not a big fan of using nightly, but such is our lot currently
 FROM --platform=linux/amd64 rust:latest as builder
 
-RUN rustup update nightly && rustup default nightly && \
+RUN rustup update nightly-2020-05-15 && rustup default nightly-2020-05-15 && \
     rustup component add rustfmt && rustup target install armv7-unknown-linux-gnueabihf && \
     rustup toolchain install nightly-armv7-unknown-linux-gnueabihf
 RUN apt-get update && apt-get install -y unzip gcc-arm-linux-gnueabihf


### PR DESCRIPTION
Rocket supposedly supports standard rust now, so this should be coming
to an end.