### PR TITLE
Change uid from 999 to 333333.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN cargo build --release -Z unstable-options --out-dir ./out
 
 FROM debian:stable-slim
 
-RUN groupadd -r -g 999 trow && useradd -r -g trow -u 999 trow
+RUN groupadd -r -g 333333 trow && useradd -r -g trow -u 333333 trow
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends openssl libssl-dev \

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -23,7 +23,7 @@ RUN cargo build --release --target aarch64-unknown-linux-gnu -Z unstable-options
 
 FROM --platform=linux/arm64 debian:stable-slim
 
-RUN groupadd -r -g 999 trow && useradd -r -g trow -u 999 trow
+RUN groupadd -r -g 333333 trow && useradd -r -g trow -u 333333 trow
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends openssl libssl-dev \

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -23,7 +23,7 @@ RUN cargo build --release --target armv7-unknown-linux-gnueabihf -Z unstable-opt
 
 FROM --platform=linux/arm/v7 debian:stable-slim
 
-RUN groupadd -r -g 999 trow && useradd -r -g trow -u 999 trow
+RUN groupadd -r -g 333333 trow && useradd -r -g trow -u 333333 trow
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends openssl libssl-dev \

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -22,7 +22,7 @@ data. This should be reattached in the case of node or pod failure, thus avoidin
 
 If your cluster does not support Persistent Volumes, or you would like to use a different driver
 (e.g. cephfs) you will need to manually assign a volume. This should be straightforward, but is
-cluster-specific. Make sure that the volume is writeable by the Trow user (user id 999 by
+cluster-specific. Make sure that the volume is writeable by the Trow user (user id 333333 by
 default). Normally this is taken care of by the `fsGroup` setting in the `securityContext` part of
 the deployment YAML, but this may not work for certain types of volume e.g. `hostPath` - in these
 cases you may need to perform an explicit `chown` or `chmod` using the UID of the Trow user.
@@ -235,7 +235,7 @@ If you get errors such as `{ code: 13, kind: PermissionDenied, message: "Permiss
 possible that Trow can't write to the data directory. Please verify that the data volume is
 accessible and writeable by the Trow user. If not, please use `chown` or `chmod` to give the Trow
 user access. As the Trow user only exists in the container, you will likely need to use it's
-equivalent UID e.g. `chown 999 /data`.
+equivalent UID e.g. `chown 333333 /data`.
 
 ### Errors When Pushing or Pulling Large Images
 

--- a/install/base/stateful-set.yaml
+++ b/install/base/stateful-set.yaml
@@ -40,9 +40,9 @@ spec:
               - key: pass
                 path: pass
       securityContext:             
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsUser: 333333
+        runAsGroup: 333333
+        fsGroup: 333333
   volumeClaimTemplates:
     - metadata:
         name: data-vol

--- a/quick-install/trow.yaml
+++ b/quick-install/trow.yaml
@@ -129,9 +129,9 @@ spec:
         - name: data-vol
           emptyDir: {}
       securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsUser: 333333
+        runAsGroup: 333333
+        fsGroup: 333333
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This is for security reasons - 999 typically maps to a system user on
the host, which gives attackers privileges in the case of a container
breakout. 333333 is unlikely to map onto anything, but respects the
/etc/user.defs convention of being in the range 10000-60000.