### PR TITLE
Allow configuring Trow's validation through Helm

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -32,6 +32,30 @@ spec:
           - {{ .Values.trow.user | quote }} 
           - "--password-file" 
           - "/etc/trow/pass"
+        {{- with .Values.trow.validation }}
+          {{- if .allowDocker }}
+          - "--allow-docker-official"
+          {{- end }}
+          {{- if not .allowKubernetes }}
+          - "--deny-k8s-images"
+          {{- end }}
+          {{- if .allowPrefixes }}
+          - "--allow-prefixes"
+          - {{ .allowPrefixes | join "," | quote }}
+          {{- end }}
+          {{- if .allowImages }}
+          - "--allow-images"
+          - {{ .allowImages | join "," | quote }}
+          {{- end }}
+          {{- if .disallowLocalPrefixes }}
+          - "--disallow-local-prefixes"
+          - {{ .disallowLocalPrefixes | join "," | quote }}
+          {{- end }}
+          {{- if .disallowLocalImages }}
+          - "--disallow-local-images"
+          - {{ .disallowLocalImages | join "," | quote }}
+          {{- end }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8000

--- a/charts/trow/templates/validatingwebhook.yaml
+++ b/charts/trow/templates/validatingwebhook.yaml
@@ -1,6 +1,10 @@
 {{- $deprecatedOption := .Values.trow.validatingWebhooks -}}
 {{ if or .Values.trow.validation.enabled $deprecatedOption }}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: admissionregistration.k8s.io/v1
+{{- else -}}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: trow-validator

--- a/charts/trow/templates/validatingwebhook.yaml
+++ b/charts/trow/templates/validatingwebhook.yaml
@@ -10,6 +10,9 @@ metadata:
   name: trow-validator
 webhooks:
   - name: {{ .Values.trow.domain }}
+    admissionReviewVersions:
+      - v1beta1
+    sideEffects: None
     rules:
       - apiGroups:
           - ""
@@ -24,4 +27,5 @@ webhooks:
       service:
         name: trow
         path: "/validate-image"
+        namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/charts/trow/templates/validatingwebhook.yaml
+++ b/charts/trow/templates/validatingwebhook.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.trow.validatingWebhooks.enabled }}
+{{- $deprecatedOption := .Values.trow.validatingWebhooks -}}
+{{ if or .Values.trow.validation.enabled $deprecatedOption }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -14,6 +14,12 @@ trow:
   password: password
   validation:
     enabled: false
+    allowDocker: false
+    allowKubernetes: true
+    allowPrefixes: []
+    allowImages: []
+    disallowLocalPrefixes: []
+    disallowLocalImages: []
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -12,7 +12,7 @@ trow:
   domain: myregistry.mydomain.io
   user: user
   password: password
-  validatingWebhooks:
+  validation:
     enabled: false
 
 imagePullSecrets: []


### PR DESCRIPTION
 I think this is the right branch, it seems this branch had more recent work on the Helm chart.

This PR adds the ability to modify the default validation configuration options through some new Helm chart values. Because I put these values under it, I also renamed the `trow.validatingWebhooks` value map to `trow.validation`.

I'm still getting a good handle on Kubernetes, so any guidance is greatly appreciated. I'm also not entirely sure I picked the right values for `admissionReviewVersions` and `sideEffects` for the validating webhooks, so some extra review on that would be appreciated.