### PR TITLE
Increase timeouts.

### DIFF
--- a/tests/manifest_history.rs
+++ b/tests/manifest_history.rs
@@ -37,7 +37,7 @@ mod interface_tests {
             .spawn()
             .expect("failed to start");
 
-        let mut timeout = 30;
+        let mut timeout = 100;
 
         let mut buf = Vec::new();
         File::open("./certs/domain.crt")

--- a/tests/registry_interface.rs
+++ b/tests/registry_interface.rs
@@ -42,7 +42,7 @@ mod interface_tests {
             .spawn()
             .expect("failed to start");
 
-        let mut timeout = 30;
+        let mut timeout = 100;
 
         let mut buf = Vec::new();
         File::open("./certs/domain.crt")

--- a/tests/smoke-test.rs
+++ b/tests/smoke-test.rs
@@ -32,7 +32,7 @@ mod interface_tests {
             .spawn()
             .expect("failed to start");
 
-        let mut timeout = 50;
+        let mut timeout = 100;
 
         let mut buf = Vec::new();
         File::open("./certs/domain.crt")

--- a/tests/validation_interface.rs
+++ b/tests/validation_interface.rs
@@ -48,7 +48,7 @@ mod validation_tests {
             .spawn()
             .expect("failed to start");
 
-        let mut timeout = 30;
+        let mut timeout = 100;
 
         let mut buf = Vec::new();
         File::open("./certs/domain.crt")


### PR DESCRIPTION
Wish I knew why this was needed, but tests are flaky otherwise.