### PR TITLE
Refactor kustomize patches for interoperability

### DIFF
--- a/install/INSTALL.md
+++ b/install/INSTALL.md
@@ -30,9 +30,8 @@ appropriate name.
  2) Open the `kustomization.yaml` file. Change the namespace to whatever namespace you want the Trow
 resources to run in. Update the YAML under `secretGenerator` with the user name and password you 
 want to use for the registry. 
- 3) Open the `patch-ingress-host.yaml` and `patch-trow-arg.yaml` files. Update the domain name to
-the domain you wish to use for your registry. Update the user name to the user name you set in the
-previous step. 
+ 3) In the same `kustomization.yaml`, update the domain name to the domain you wish to use for your 
+ registry. Update the user name to the user name you set in the previous step. 
  2) Run `kubectl apply -k overlays/mycluster` from the install directory.
  3) Set the DNS for your domain to point to the IP for your ingress, which you can find with `kubectl
  get ingress -n trow`. Note that in GKE, this IP is subject to change unless you obtain a static IP.
@@ -41,8 +40,8 @@ previous step.
  get TLS errors whilst the certificate is being provisioned.
 
 If you're using a Google ManagedCertificate, change the base in `kustomization.yaml` to `../gke` and
-replace `patch-ingress-host.yaml` with a copy of `patch-cert-domain.yaml` from the `overlays/gke`
-directory and edit as appropriate.
+replace the `Ingress` patch with a copy of `ManagedCertificate` patch from the
+`overlays/gke/kustomization.yaml` directory and edit as appropriate.
 
 For other installs, please use the provided files as a base and consider contributing new
 overlays back to the project.
@@ -58,10 +57,13 @@ resources:
 - ../../base/validate.yaml
 ```
 
-And also the following under `patchesJson6902`:
+And also uncomment the following under `patchesJson6902` and modify the domain value:
 
-```
-    - path: patch-validator-domain.yaml
+```yaml
+    - patch: |-
+        - op: replace
+          path: /webhooks/0/name
+          value: example.registry.com
       target:
         kind: ValidatingWebhookConfiguration
         name: trow-validator
@@ -69,10 +71,7 @@ And also the following under `patchesJson6902`:
         version: v1
 ```
 
- 2) Copy the file `base/patch-validator-domain.yaml` to your directory and edit to point to the
-domain name of your registry.
-
- 3) Run `kubectl apply -k overlays/mycluster` from the install directory.
+ 2) Run `kubectl apply -k overlays/mycluster` from the install directory.
 
 It would be better to point Kubernetes at the internal Trow service in step 2, but as this isn't
 running over TLS within the internal network in the default install, we need to use the external

--- a/install/base/kustomization.yaml
+++ b/install/base/kustomization.yaml
@@ -30,14 +30,20 @@ images:
 
 
 patchesJson6902:
-#    - path: patch-trow-arg.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /spec/template/spec/containers/0/args/2
+#          value: newregistry.mydomain.com
 #      target:
 #        kind: StatefulSet
 #        name: trow-set
 #        group: apps
 #        version: v1
 #
-#    - path: patch-validator-domain.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /webhooks/0/name
+#          value: newregistry.mydomain.com
 #      target:
 #        kind: ValidatingWebhookConfiguration
 #        name: trow-validator

--- a/install/base/patch-trow-arg.yaml
+++ b/install/base/patch-trow-arg.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/template/spec/containers/0/args/2
-  value: newregistry.mydomain.com

--- a/install/base/patch-validator-domain.yaml
+++ b/install/base/patch-validator-domain.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /webhooks/0/name
-  value: newregistry.mydomain.com

--- a/install/overlays/cert-manager-nginx/kustomization.yaml
+++ b/install/overlays/cert-manager-nginx/kustomization.yaml
@@ -12,10 +12,15 @@ resources:
 
 
 # The following patches update the domain name in the ingress without editing the yaml. 
-# Create your own version of the patch file with your domain name and reference in your overlay as
-# below:
+# Modify it to your needs:
 #patchesJson6902:
-#    - path: patch-ingress-host.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /spec/rules/0/host
+#          value: newregistry.mydomain.com
+#        - op: replace
+#          path: /spec/tls/0/hosts/0
+#          value: newregistry.mydomain.com
 #      target:
 #          kind: Ingress
 #          name: trow-ingress

--- a/install/overlays/cert-manager-nginx/patch-ingress-host.yaml
+++ b/install/overlays/cert-manager-nginx/patch-ingress-host.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/rules/0/host
-  value: newregistry.mydomain.com
-- op: replace
-  path: /spec/tls/0/hosts/0
-  value: newregistry.mydomain.com

--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -21,20 +21,34 @@ secretGenerator:
     - docker-password=s3cr3tp@55
 
 patchesJson6902:
-  - path: patch-ingress-host.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: example.registry.com
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: example.registry.com
     target:
       kind: Ingress
       name: trow-ingress
       group: extensions
       version: v1beta1
-  - path: patch-trow-arg.yaml
+  - patch: |-
+      - op: replace #domain name
+        path: /spec/template/spec/containers/0/args/2
+        value: example.registry.com
+      - op: replace #user name
+        path: /spec/template/spec/containers/0/args/4
+        value: example
     target:
       kind: StatefulSet
       name: trow-set
       group: apps
       version: v1
-
-#    - path: patch-validator-domain.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /webhooks/0/name
+#          value: example.registry.com
 #      target:
 #        kind: ValidatingWebhookConfiguration
 #        name: trow-validator

--- a/install/overlays/example-overlay/patch-ingress-host.yaml
+++ b/install/overlays/example-overlay/patch-ingress-host.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/rules/0/host
-  value: example.registry.com
-- op: replace
-  path: /spec/tls/0/hosts/0
-  value: example.registry.com

--- a/install/overlays/example-overlay/patch-trow-arg.yaml
+++ b/install/overlays/example-overlay/patch-trow-arg.yaml
@@ -1,6 +1,0 @@
-- op: replace #domain name
-  path: /spec/template/spec/containers/0/args/2
-  value: example.registry.com
-- op: replace #user name
-  path: /spec/template/spec/containers/0/args/4
-  value: example

--- a/install/overlays/gke/kustomization.yaml
+++ b/install/overlays/gke/kustomization.yaml
@@ -15,11 +15,13 @@ resources:
     - ingress.yaml
 
 # The following patch updates the certificate domain name without editing the yaml. 
-# Create your own version of the patch file with your domain name and reference in your overlay as
-# below:
+# Modify it to your needs:
 
 #patchesJson6902:
-#    - path: patch-cert-domain.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /spec/domains/0
+#          value: newregistry.mydomain.com
 #      target:
 #        kind: ManagedCertificate
 #        name: trow-certificate

--- a/install/overlays/gke/patch-cert-domain.yaml
+++ b/install/overlays/gke/patch-cert-domain.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/domains/0
-  value: newregistry.mydomain.com


### PR DESCRIPTION
non-GVK'ded yaml files break some CM tools such as the very
`kustomize/kpt cfg` subcommand. Instead of removing the yaml extension,
which might be deceptive, inline the patches.

Proof: error in https://github.com/ContainerSolutions/trow/issues/183#issue-716028785