### PR TITLE
Use named ports

### DIFF
--- a/install/base/service.yaml
+++ b/install/base/service.yaml
@@ -7,7 +7,8 @@ spec:
     app: trow
   type: NodePort
   ports:
-  - protocol: TCP
+  - name: http-tcp
+    protocol: TCP
     port: 8000
-    targetPort: 8000
+    targetPort: trow-http-port
 

--- a/install/base/stateful-set.yaml
+++ b/install/base/stateful-set.yaml
@@ -25,7 +25,8 @@ spec:
           - "/etc/trow/pass"
         imagePullPolicy: Always
         ports:
-        - containerPort: 8000
+        - name: trow-http-port
+          containerPort: 8000
         volumeMounts:
         - name: data-vol
           mountPath: /data

--- a/install/overlays/cert-manager-nginx/ingress.yaml
+++ b/install/overlays/cert-manager-nginx/ingress.yaml
@@ -16,7 +16,7 @@ spec:
           - path: /
             backend:
               serviceName: trow-svc
-              servicePort: 8000
+              servicePort: http-tcp
   tls: 
     - hosts:
         - myregistry.mydomain.io

--- a/install/overlays/gke/ingress.yaml
+++ b/install/overlays/gke/ingress.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   backend:
     serviceName: trow-svc
-    servicePort: 8000
+    servicePort: http-tcp


### PR DESCRIPTION
Named ports helps with better reasoning over the service's port
abstractions.

<sub>a series of perceived tiny improvements from while working on #193</sub>