### PR TITLE
Add https port definition

### DIFF
--- a/install/base/service.yaml
+++ b/install/base/service.yaml
@@ -11,4 +11,8 @@ spec:
     protocol: TCP
     port: 8000
     targetPort: trow-http-port
+  - name: https-tcp
+    protocol: TCP
+    port: 8443
+    targetPort: trow-https-port
 

--- a/install/base/stateful-set.yaml
+++ b/install/base/stateful-set.yaml
@@ -27,6 +27,8 @@ spec:
         ports:
         - name: trow-http-port
           containerPort: 8000
+        - name: trow-https-port
+          containerPort: 8443
         volumeMounts:
         - name: data-vol
           mountPath: /data


### PR DESCRIPTION
Atop #205 

That keeps downstream kustomization files a little cleaner.

Maybe there are ways to also add it to the two ingress controllers
(as convenience defaults) without breaking anything?

if this is at risk of causing any troubles, better let's drop it.

<sub>a series of perceived tiny improvements from while working on #193</sub>