### PR TITLE
Don't use nodeport service for production dpeloyments

### DIFF
--- a/install/base/service.yaml
+++ b/install/base/service.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     app: trow
-  type: NodePort
   ports:
   - protocol: TCP
     port: 8000


### PR DESCRIPTION
In production, users should not be "nudged" into using node ports.
Rather a proper deployment would include a proper ingress controller.

_I might be missing something, but I'll put this on the table to at least discuss and gain clarity._

<sub>a series of perceived tiny improvements from while working on #193</sub>