### PR TITLE
Unecesary configuration

### DIFF
--- a/install/base/kustomization.yaml
+++ b/install/base/kustomization.yaml
@@ -39,13 +39,3 @@ patchesJson6902:
 #        name: trow-set
 #        group: apps
 #        version: v1
-#
-#    - patch: |-
-#        - op: replace
-#          path: /webhooks/0/name
-#          value: newregistry.mydomain.com
-#      target:
-#        kind: ValidatingWebhookConfiguration
-#        name: trow-validator
-#        group: admissionregistration.k8s.io
-#        version: v1

--- a/install/base/validate.yaml
+++ b/install/base/validate.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: trow-validator
 webhooks:
-  - name: myregistry.mydomain.com
+  - name: validator.trow.io
     rules:
       - apiGroups:
           - ""

--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -45,12 +45,3 @@ patchesJson6902:
       name: trow-set
       group: apps
       version: v1
-#    - patch: |-
-#        - op: replace
-#          path: /webhooks/0/name
-#          value: example.registry.com
-#      target:
-#        kind: ValidatingWebhookConfiguration
-#        name: trow-validator
-#        group: admissionregistration.k8s.io
-#        version: v1


### PR DESCRIPTION
From looking at:
https://github.com/ContainerSolutions/trow/blob/master/quick-install/validate-tmpl.yaml#L6

It appeared to me that this configuration is not necessary and the value can be fixed to `validator.trow.io`.

Changing it appeared to me a cosmetic thing (which should not induce users into thinking it might be actually relevant). Am I missing something?

If this is ok, I should probably update docs and polish this further.