### PR TITLE
Set Docker-Content-Digest header.

### DIFF
--- a/src/response/blob_reader.rs
+++ b/src/response/blob_reader.rs
@@ -5,11 +5,14 @@ use rocket::response::{self, Responder, Stream};
 
 impl<'r> Responder<'r> for BlobReader {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        let mut resp = Stream::from(self.get_reader()).respond_to(req)?;
-        //Not sure this is the right content type
+        
         let ct = Header::new("Content-Type", "application/octet-stream");
+        let digest = Header::new("Docker-Content-Digest", self.digest().0.clone());
+       
+        let mut resp = Stream::from(self.get_reader()).respond_to(req)?;
         resp.set_header(ct);
-
+        resp.set_header(digest);
+     
         Ok(resp)
     }
 }

--- a/src/response/blob_reader.rs
+++ b/src/response/blob_reader.rs
@@ -5,14 +5,13 @@ use rocket::response::{self, Responder, Stream};
 
 impl<'r> Responder<'r> for BlobReader {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        
         let ct = Header::new("Content-Type", "application/octet-stream");
         let digest = Header::new("Docker-Content-Digest", self.digest().0.clone());
-       
+
         let mut resp = Stream::from(self.get_reader()).respond_to(req)?;
         resp.set_header(ct);
         resp.set_header(digest);
-     
+
         Ok(resp)
     }
 }

--- a/src/response/manifest_reader.rs
+++ b/src/response/manifest_reader.rs
@@ -6,8 +6,11 @@ use rocket::response::{self, Responder, Stream};
 impl<'r> Responder<'r> for ManifestReader {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
         let ct = Header::new("Content-Type", self.content_type().to_string());
+        let digest = Header::new("Docker-Content-Digest", self.digest().0.clone());
+
         let mut resp = Stream::from(self.get_reader()).respond_to(req)?;
         resp.set_header(ct);
+        resp.set_header(digest);
 
         Ok(resp)
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -81,6 +81,8 @@ pub async fn upload_layer(cl: &reqwest::Client, name: &str, tag: &str) {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+    let digest_header = resp.headers().get("Docker-Content-Digest").unwrap().to_str().unwrap();
+    assert_eq!(digest, digest_header);
     assert_eq!(blob, resp.bytes().await.unwrap());
 
     //Upload manifest

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -81,7 +81,12 @@ pub async fn upload_layer(cl: &reqwest::Client, name: &str, tag: &str) {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let digest_header = resp.headers().get("Docker-Content-Digest").unwrap().to_str().unwrap();
+    let digest_header = resp
+        .headers()
+        .get("Docker-Content-Digest")
+        .unwrap()
+        .to_str()
+        .unwrap();
     assert_eq!(digest, digest_header);
     assert_eq!(blob, resp.bytes().await.unwrap());
 

--- a/tests/registry_interface.rs
+++ b/tests/registry_interface.rs
@@ -108,7 +108,10 @@ mod interface_tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+        //Just check header exists for minute
+        resp.headers().get("Docker-Content-Digest").unwrap().to_str().unwrap();
         let mani: manifest::ManifestV2 = resp.json().await.unwrap();
+
         assert_eq!(mani.schema_version, 2);
     }
 

--- a/tests/registry_interface.rs
+++ b/tests/registry_interface.rs
@@ -109,7 +109,11 @@ mod interface_tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         //Just check header exists for minute
-        resp.headers().get("Docker-Content-Digest").unwrap().to_str().unwrap();
+        resp.headers()
+            .get("Docker-Content-Digest")
+            .unwrap()
+            .to_str()
+            .unwrap();
         let mani: manifest::ManifestV2 = resp.json().await.unwrap();
 
         assert_eq!(mani.schema_version, 2);


### PR DESCRIPTION
It's not in the spec yet, but it enables a very useful use case where a client can get back the digest of a blob/manifest without having to do a full GET.

When the spec is updated, the name will presumably change.