### PR TITLE
Updated the chart to support using the new 0.3.1-PROXY image to use trow as a proxy for docker hub

### DIFF
--- a/charts/trow/Chart.yaml
+++ b/charts/trow/Chart.yaml
@@ -3,5 +3,5 @@ name: trow
 description: Helm chart for Trow registry
 
 type: application
-version: 0.3.0
-appVersion: 0.3.0
+version: 0.3.1
+appVersion: 0.3.1-PROXY

--- a/charts/trow/Chart.yaml
+++ b/charts/trow/Chart.yaml
@@ -3,5 +3,5 @@ name: trow
 description: Helm chart for Trow registry
 
 type: application
-version: 0.3.1
-appVersion: 0.3.1-PROXY
+version: 0.3.2
+appVersion: 0.3.2

--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -22,9 +22,9 @@ spec:
     {{- end }}
       containers:
       - name: trow-pod
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: 
+        args:
           - "--no-tls" 
           - "-n" 
           - {{ .Values.trow.domain | quote }}
@@ -34,7 +34,10 @@ spec:
           - "--password-file" 
           - "/etc/trow/pass"
           {{- end }}
-        {{- with .Values.trow.validation }}
+        {{- with .Values.trow.validation }} 
+          {{- if .proxyDockerHub }}
+          - "--proxy-docker-hub"
+          {{- end }}
           {{- if .allowDocker }}
           - "--allow-docker-official"
           {{- end }}

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -21,7 +21,7 @@ trow:
     allowImages: []
     disallowLocalPrefixes: []
     disallowLocalImages: []
-    proxyDockerHub: true
+    proxyDockerHub: false
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 image:
   repository: containersol/trow
+  tag: 0.3.1-PROXY
   pullPolicy: Always
 
 trow:
@@ -20,6 +21,7 @@ trow:
     allowImages: []
     disallowLocalPrefixes: []
     disallowLocalImages: []
+    proxyDockerHub: true
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
I updated the chart version and the appVersion. I also added values to the values.yaml and parameters to the statefulset.yaml  to accept them for passing the image tag and the --proxy-docker-hub arguments.