### PR TITLE
Replaces user and PAT with secret values for easier maintenance

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Login to package repos
       run: |
-          echo "${{secrets.GHCR_PAT}}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{secrets.CR_PAT}}" | docker login ghcr.io -u ${{secrets.CR_USER}} --password-stdin
           echo "${{secrets.DOCKERHUB_PASS}}" | docker login -u ${{secrets.DOCKERHUB_USER}} --password-stdin
     - name: Install buildx
       run: |


### PR DESCRIPTION
Replaces login to ghcr.io user with the value from secret, so it's easier to update. 
Renames the token to CR_PAT as per github how to (not very important, but makes it more consistent) - https://docs.github.com/en/free-pro-team@latest/packages/guides/pushing-and-pulling-docker-images#authenticating-to-github-container-registry