### PR TITLE
Reverted some changes of PR#237.

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
       containers:
       - name: trow-pod
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - "--no-tls" 

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -6,7 +6,6 @@ replicaCount: 1
 
 image:
   repository: containersol/trow
-  tag: 0.3.1-PROXY
   pullPolicy: Always
 
 trow:


### PR DESCRIPTION
So I think this was merged by accident, we don't want this, it pins version 0.3.1-proxy in our chart. 

This was probably submitted because our helm chart wasn't updated for some time.