### PR TITLE
skip only blob which is already downloaded

### DIFF
--- a/lib/server/src/server.rs
+++ b/lib/server/src/server.rs
@@ -430,10 +430,11 @@ impl TrowServer {
         //TODO: change to perform dloads async
         for digest in mani.get_local_asset_digests() {
 
-            //break if have digest
+            //skip only blob if it already exists in local storage
+            //we need to continue as docker images may share blobs
             if self.get_catalog_path_for_blob(digest)?.exists() {
                 info!("Already have blob {}", digest);    
-                break;
+                continue;
             }
             let addr = format!("{}/{}/blobs/{}", remote_image.host, remote_image.repo, digest);
             info!("Downloading blob {}", addr);


### PR DESCRIPTION
we need to continue as docker manifests may share blobs
for example they may have same FROM