### PR TITLE
Fix nightly version in Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
 #Not a big fan of using nightly, but such is our lot currently
 FROM rust:latest as builder
 
-RUN rustup default nightly-2021-01-30 && rustup component add rustfmt
+#RUN rustup default nightly-2021-01-30 && rustup component add rustfmt
+RUN rustup toolchain install nightly --allow-downgrade -c rustfmt
+RUN rustup default nightly
 RUN apt-get update && apt-get install -y unzip
 
 WORKDIR /usr/src/trow

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -4,9 +4,8 @@
 #Not a big fan of using nightly, but such is our lot currently
 #Note we build on amd64 and cross-compile to arch
 FROM --platform=linux/amd64 rust:latest as builder
-RUN rustup update nightly-2021-01-30 && rustup default nightly-2021-01-30 && \
-    rustup component add rustfmt && rustup target install aarch64-unknown-linux-gnu && \
-    rustup toolchain install nightly-aarch64-unknown-linux-gnu
+RUN rustup toolchain install nightly --allow-downgrade -c rustfmt && rustup default nightly && \
+    rustup target add aarch64-unknown-linux-gnu 
 RUN apt-get update && apt-get install -y unzip gcc-aarch64-linux-gnu
 WORKDIR /usr/src/trow
 

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -4,9 +4,8 @@
 #Not a big fan of using nightly, but such is our lot currently
 FROM --platform=linux/amd64 rust:latest as builder
 
-RUN rustup update nightly-2021-01-30 && rustup default nightly-2021-01-30 && \
-    rustup component add rustfmt && rustup target install armv7-unknown-linux-gnueabihf && \
-    rustup toolchain install nightly-armv7-unknown-linux-gnueabihf
+RUN rustup toolchain install nightly --allow-downgrade -c rustfmt && rustup default nightly && \
+    rustup target add armv7-unknown-linux-gnueabihf
 RUN apt-get update && apt-get install -y unzip gcc-arm-linux-gnueabihf
 WORKDIR /usr/src/trow
 


### PR DESCRIPTION
Again trying to stop specifying value.

This will probably break again at some horrible point.