### PR TITLE
Add CLI parameter for setting the log level

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,13 @@ Must be used with --hub-token or --hub-token-file")
             .help("Maximum size in mebibytes of \"blob\" that can be uploaded (a single layer of an image). This can be very large in some images (GBs).")
             .takes_value(true)
         )
+        .arg(
+            Arg::with_name("log-level")
+            .long("log-level")
+            .value_name("log-level")
+            .help("The log level at which to output to stdout, valid values are OFF, ERROR, WARN, INFO, DEBUG and TRACE")
+            .takes_value(true)
+        )
         .get_matches()
 }
 
@@ -232,6 +239,8 @@ fn main() {
         println!("Trow version {} {}", env!("CARGO_PKG_VERSION"), vcs_ref);
         std::process::exit(0);
     }
+
+    let log_level = matches.value_of("log-level").unwrap_or("error");
 
     let no_tls = matches.is_present("no-tls");
     let host = matches.value_of("host").unwrap_or("0.0.0.0");
@@ -292,6 +301,7 @@ fn main() {
         cors,
         max_manifest_size,
         max_blob_size,
+        log_level.to_string(),
     );
     if !no_tls {
         builder.with_tls(cert_path.to_string(), key_path.to_string());

--- a/src/response/test_helper.rs
+++ b/src/response/test_helper.rs
@@ -34,6 +34,7 @@ pub fn test_client() -> Client {
         token_secret: "secret".to_string(),
         user: None,
         cors: false,
+        log_level: "error".to_string(),
     };
     let rocket = rocket::Rocket::build()
         .manage(trow_config)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -139,4 +139,11 @@ mod cli {
             .fails()
             .unwrap();
     }
+
+    #[test]
+    fn log_level_setting() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["--log-level", "TRACE"])
+            .succeeds();
+    }
 }


### PR DESCRIPTION
Attempt to address https://github.com/ContainerSolutions/trow/issues/270

While I have _some_ Rust experience this is my first time contributing to a project, your issues section is really well maintained with good 'first issue' labels, so thanks for that :)

Happy to expand on any tests, just didn't seem to be that many great hooks into doing assertions.

- Defaults to "ERROR" to match existing behaviour
- Gives RUST_LOG env var priority to match legacy behaviour
- Documents the valid settings
