### PR TITLE
Fix ranges

### DIFF
--- a/src/client_interface.rs
+++ b/src/client_interface.rs
@@ -193,7 +193,7 @@ impl BlobStorage for ClientInterface {
         let total = sink.seek(SeekFrom::End(0)).await.unwrap_or(chunk_len);
         if have_range {
             if (info.range.1 + 1) != total {
-                warn!("total {} r + 1 {}", total, info.range.1 + 1 + 1);
+                warn!("total {} r + 1 {}", total, info.range.1 + 1);
                 return Err(StorageDriverError::InvalidContentRange);
             }
             //Check length if chunked upload

--- a/src/routes/blob.rs
+++ b/src/routes/blob.rs
@@ -165,6 +165,7 @@ pub async fn put_blob(
             _ => Error::InternalError,
         })?;
 
+    log::debug!("size {} u32 {}", size, (size as u32));
     Ok(create_accepted_upload(
         digest_obj,
         RepoName(repo_name),

--- a/src/routes/blob.rs
+++ b/src/routes/blob.rs
@@ -165,12 +165,11 @@ pub async fn put_blob(
             _ => Error::InternalError,
         })?;
 
-    log::debug!("size {} u32 {}", size, (size as u32));
     Ok(create_accepted_upload(
         digest_obj,
         RepoName(repo_name),
         Uuid(uuid),
-        (0, (size as u32)),
+        (0, (size as u32).checked_sub(1).unwrap_or(0)), // Note first byte is 0
     ))
 }
 
@@ -336,7 +335,7 @@ pub async fn patch_blob(
                 Ok(create_upload_info(
                     uuid,
                     repo_name,
-                    (0, stored.total_stored as u32),
+                    (0, (stored.total_stored as u32).checked_sub(1).unwrap_or(0)), // First byte is 0
                 ))
             }
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -64,6 +64,8 @@ pub async fn upload_layer(cl: &reqwest::Client, name: &str, tag: &str) {
         .await
         .expect("Failed to send patch request");
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    let range = resp.headers().get(RANGE_HEADER).unwrap().to_str().unwrap();
+    assert_eq!(range, format!("0-{}", (blob.len() -1 ))); //note first byte is 0, hence len - 1
 
     let digest = digest::sha256_tag_digest(BufReader::new(blob.as_slice())).unwrap();
     let resp = cl

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,6 +15,8 @@ pub const DIST_API_HEADER: &str = "Docker-Distribution-API-Version";
 pub const UPLOAD_HEADER: &str = "Docker-Upload-Uuid";
 #[allow(dead_code)]
 pub const LOCATION_HEADER: &str = "Location";
+#[allow(dead_code)]
+pub const RANGE_HEADER: &str = "Range";
 
 #[cfg(test)]
 #[allow(dead_code)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -65,7 +65,7 @@ pub async fn upload_layer(cl: &reqwest::Client, name: &str, tag: &str) {
         .expect("Failed to send patch request");
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
     let range = resp.headers().get(RANGE_HEADER).unwrap().to_str().unwrap();
-    assert_eq!(range, format!("0-{}", (blob.len() -1 ))); //note first byte is 0, hence len - 1
+    assert_eq!(range, format!("0-{}", (blob.len() - 1))); //note first byte is 0, hence len - 1
 
     let digest = digest::sha256_tag_digest(BufReader::new(blob.as_slice())).unwrap();
     let resp = cl

--- a/tests/registry_interface.rs
+++ b/tests/registry_interface.rs
@@ -183,7 +183,12 @@ mod interface_tests {
             .to_str()
             .unwrap();
 
-        let range = resp.headers().get(common::RANGE_HEADER).unwrap().to_str().unwrap();
+        let range = resp
+            .headers()
+            .get(common::RANGE_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert_eq!(range, "0-0"); // Haven't uploaded anything yet
 
         //used by oci_manifest_test
@@ -196,8 +201,13 @@ mod interface_tests {
 
         let resp = cl.put(loc).body(config).send().await.unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
-        let range = resp.headers().get(common::RANGE_HEADER).unwrap().to_str().unwrap();
-        assert_eq!(range, format!("0-{}", (config.len() -1 ))); //note first byte is 0, hence len - 1
+        let range = resp
+            .headers()
+            .get(common::RANGE_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(range, format!("0-{}", (config.len() - 1))); //note first byte is 0, hence len - 1
     }
 
     async fn upload_with_post(cl: &reqwest::Client, name: &str) {
@@ -213,8 +223,13 @@ mod interface_tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
-        let range = resp.headers().get(common::RANGE_HEADER).unwrap().to_str().unwrap();
-        assert_eq!(range, format!("0-{}", (config.len() -1 ))); //note first byte is 0, hence len - 1
+        let range = resp
+            .headers()
+            .get(common::RANGE_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(range, format!("0-{}", (config.len() - 1))); //note first byte is 0, hence len - 1
     }
 
     async fn push_oci_manifest(cl: &reqwest::Client, name: &str, tag: &str) -> String {

--- a/tests/registry_interface.rs
+++ b/tests/registry_interface.rs
@@ -183,6 +183,9 @@ mod interface_tests {
             .to_str()
             .unwrap();
 
+        let range = resp.headers().get(common::RANGE_HEADER).unwrap().to_str().unwrap();
+        assert_eq!(range, "0-0"); // Haven't uploaded anything yet
+
         //used by oci_manifest_test
         let config = "{}\n".as_bytes();
         let digest = digest::sha256_tag_digest(BufReader::new(config)).unwrap();
@@ -193,6 +196,8 @@ mod interface_tests {
 
         let resp = cl.put(loc).body(config).send().await.unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
+        let range = resp.headers().get(common::RANGE_HEADER).unwrap().to_str().unwrap();
+        assert_eq!(range, format!("0-{}", (config.len() -1 ))); //note first byte is 0, hence len - 1
     }
 
     async fn upload_with_post(cl: &reqwest::Client, name: &str) {
@@ -208,6 +213,8 @@ mod interface_tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
+        let range = resp.headers().get(common::RANGE_HEADER).unwrap().to_str().unwrap();
+        assert_eq!(range, format!("0-{}", (config.len() -1 ))); //note first byte is 0, hence len - 1
     }
 
     async fn push_oci_manifest(cl: &reqwest::Client, name: &str, tag: &str) -> String {


### PR DESCRIPTION
As per #302, range handling was broken in some parts of Trow. (Strangely enough, it was correct in some other parts!)

This fixes the problem at a slightly different level to #302 (where the ranges are created) and adds tests.