### PR TITLE
Add multiplatform (manifest list) proxying + fix concurrent writes to files + add concurrent download of layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2661,7 @@ dependencies = [
 name = "trow-server"
 version = "0.3.5"
 dependencies = [
+ "async-recursion",
  "async-stream",
  "bytes",
  "chrono",

--- a/lib/server/Cargo.lock
+++ b/lib/server/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1542,7 @@ dependencies = [
 name = "trow-server"
 version = "0.3.5"
 dependencies = [
+ "async-recursion",
  "async-stream",
  "bytes",
  "chrono",
@@ -1552,6 +1564,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/lib/server/Cargo.toml
+++ b/lib/server/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0"
 prost = "0.9"
 prost-types = "0.9"
 rand = "0.8"
-tokio = { version = "1", features = ["macros", "sync", "time", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "sync", "time", "rt-multi-thread", "fs"] }
 tokio-stream = "0.1"
 chrono = "0.4"
 tonic = "0.6"
@@ -27,7 +27,6 @@ serde_derive = "^1.0"
 trow-protobuf = { path = "../protobuf" }
 rustc-serialize = "0.3"
 reqwest = { version = "0.11", features = ["json"] }
-
 prometheus = { version = "0.13"}
 lazy_static = "1.4.0"
 fs3 = "0.5.0"
@@ -40,3 +39,4 @@ quoted-string = "0.6.1"
 tonic-build = "0.6"
 
 [dev-dependencies]
+tempfile = "3.3"

--- a/lib/server/Cargo.toml
+++ b/lib/server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 authors = ["Adrian Mouat <adrian.mouat@container-solutions.com" ]
 
 [dependencies]
+async-recursion = "1.0"
 futures = "0.3"
 async-stream = "0.3"
 bytes = "1"

--- a/lib/server/src/lib.rs
+++ b/lib/server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod digest;
 use tonic::transport::Server;
 mod metrics;
 mod server;
+mod temporary_file;
 mod validate;
 use log::{debug, warn};
 use server::trow_server::admission_controller_server::AdmissionControllerServer;

--- a/lib/server/src/server.rs
+++ b/lib/server/src/server.rs
@@ -13,7 +13,7 @@ use async_recursion::async_recursion;
 use chrono::prelude::*;
 use failure::format_err;
 use failure::{self, Error, Fail};
-use futures::future::{join_all, try_join_all};
+use futures::future::try_join_all;
 use log::{debug, error, info, warn};
 use prost_types::Timestamp;
 use quoted_string::strip_dquotes;

--- a/lib/server/src/server.rs
+++ b/lib/server/src/server.rs
@@ -127,7 +127,7 @@ fn create_accept_header() -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
         reqwest::header::ACCEPT,
-        HeaderValue::from_str(&ACCEPT.join(", ")).unwrap()
+        HeaderValue::from_str(&ACCEPT.join(", ")).unwrap(),
     );
     headers
 }
@@ -459,7 +459,8 @@ impl TrowServer {
         let mani: Manifest = serde_json::from_slice(&bytes)?;
 
         if let Manifest::List(_) = mani {
-            let images_to_dl = mani.get_local_asset_digests()
+            let images_to_dl = mani
+                .get_local_asset_digests()
                 .into_iter()
                 .map(|digest| {
                     let mut image = remote_image.clone();
@@ -467,7 +468,8 @@ impl TrowServer {
                     image
                 })
                 .collect::<Vec<_>>();
-            let futures = images_to_dl.iter()
+            let futures = images_to_dl
+                .iter()
                 .map(|img| self.download_manifest_and_layers(cl, token, &img, local_repo_name));
             try_join_all(futures).await?;
         } else {

--- a/lib/server/src/server.rs
+++ b/lib/server/src/server.rs
@@ -756,15 +756,6 @@ impl TrowServer {
             Err(e) => Err(e),
         };
 
-        //Not an error, even if it's not great
-        fs::remove_file(&scratch_path).unwrap_or_else(|e| {
-            error!(
-                "Error deleting file {} {:?}",
-                &scratch_path.to_string_lossy(),
-                e
-            )
-        });
-
         res?;
         Ok(())
     }
@@ -1029,9 +1020,6 @@ impl Registry for TrowServer {
                         );
                         Status::internal("Internal error copying manifest")
                     });
-
-                fs::remove_file(&uploaded_manifest)
-                    .unwrap_or_else(|e| error!("Failure deleting uploaded manifest {:?}", e));
 
                 ret
             }

--- a/lib/server/src/server.rs
+++ b/lib/server/src/server.rs
@@ -117,10 +117,11 @@ pub struct Auth {
 }
 
 fn create_accept_header() -> HeaderMap {
-    const ACCEPT: [&str; 3] = [
+    const ACCEPT: [&str; 4] = [
         manifest_media_type::OCI_V1,
         manifest_media_type::DOCKER_V2,
         manifest_media_type::DOCKER_LIST,
+        manifest_media_type::OCI_INDEX,
     ];
 
     let mut headers = HeaderMap::new();

--- a/lib/server/src/temporary_file.rs
+++ b/lib/server/src/temporary_file.rs
@@ -50,7 +50,7 @@ mod test {
     use super::*;
     use futures::future::try_join_all;
     use tempfile::tempdir;
-    use tokio::time::Duration;
+    use tokio::time::{sleep, Duration};
 
     #[tokio::test]
     async fn test_temporary_file() {
@@ -86,6 +86,8 @@ mod test {
                     None => return Err(()),
                 };
                 file.write_all(b"hello").await.unwrap();
+                sleep(Duration::from_millis(500)).await;
+                drop(file);
                 Ok(())
             }
         });

--- a/lib/server/src/temporary_file.rs
+++ b/lib/server/src/temporary_file.rs
@@ -79,16 +79,17 @@ mod test {
         let path = dir.path().join("test.txt");
 
         let futures = (0..2).map(|_| {
-            let path = path.clone();
-            async move {
+            async {
                 let mut file = match TemporaryFile::open_for_writing(path.clone()).await.unwrap() {
                     Some(f) => f,
-                    None => return Err(()),
+                    None => return Err(()) as Result<(), ()>,
                 };
                 file.write_all(b"hello").await.unwrap();
+                // Sleep to ensure that the future stay active long enough to be cancelled
                 sleep(Duration::from_millis(500)).await;
+                // Ensure `file` isn't droped before the sleep
                 drop(file);
-                Ok(())
+                unreachable!();
             }
         });
 

--- a/lib/server/src/temporary_file.rs
+++ b/lib/server/src/temporary_file.rs
@@ -1,0 +1,100 @@
+use std::path::{Path, PathBuf};
+use tokio::fs::{self, File};
+use tokio::io::{self, AsyncWriteExt};
+
+/// Designed for downloading files. The [`Drop`] implementation makes sure that
+/// the underlying file is deleted in case of an error.
+/// Intended use: create the [`TemporaryFile`], write to it, then move
+/// the underlying file to its final destination.
+pub struct TemporaryFile {
+    file: File,
+    path: PathBuf,
+}
+
+impl TemporaryFile {
+    /// Returns `Ok(None)` if the file already exists.
+    pub async fn open_for_writing(path: PathBuf) -> io::Result<Option<TemporaryFile>> {
+        let res = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .await;
+        let file = match res {
+            Ok(f) => f,
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::AlreadyExists => {
+                    return Ok(None);
+                }
+                _ => return Err(e.into()),
+            },
+        };
+        Ok(Some(TemporaryFile { file, path }))
+    }
+    pub async fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.file.write_all(buf).await
+    }
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Special drop to ensure that the file is removed
+impl Drop for TemporaryFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::future::try_join_all;
+    use tempfile::tempdir;
+    use tokio::time::Duration;
+
+    #[tokio::test]
+    async fn test_temporary_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        let mut file = TemporaryFile::open_for_writing(path.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            TemporaryFile::open_for_writing(path.clone())
+                .await
+                .unwrap()
+                .is_none(),
+            "The same file cannot be opened for writing twice !"
+        );
+        file.write_all(b"hello").await.unwrap();
+        assert_eq!(file.path(), path);
+        drop(file);
+        assert!(!path.exists(), "File should have been deleted");
+    }
+
+    #[tokio::test]
+    async fn test_temporary_file_async_cancellation() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+
+        let futures = (0..2).map(|_| {
+            let path = path.clone();
+            async move {
+                let mut file = match TemporaryFile::open_for_writing(path.clone()).await.unwrap() {
+                    Some(f) => f,
+                    None => return Err(()),
+                };
+                file.write_all(b"hello").await.unwrap();
+                Ok(())
+            }
+        });
+
+        let res = try_join_all(futures).await;
+        assert!(
+            res.is_err(),
+            "The same file cannot be opened for writing twice !"
+        );
+        assert!(!path.exists(), "File should have been deleted");
+    }
+}

--- a/tests/manifest_history.rs
+++ b/tests/manifest_history.rs
@@ -79,7 +79,7 @@ mod interface_tests {
                 "{}/v2/{}/blobs/uploads/?digest={}",
                 TROW_ADDRESS, "config", digest
             ))
-            .body(config.clone())
+            .body(config)
             .send()
             .await
             .unwrap();
@@ -102,10 +102,10 @@ mod interface_tests {
         }
 
         let manifest = format!(
-            r#"{{ "mediaType": "application/vnd.oci.image.manifest.v1+json", 
-                 "config": {{ "digest": "{}", 
-                             "mediaType": "application/vnd.oci.image.config.v1+json", 
-                             "size": {} }}, 
+            r#"{{ "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                 "config": {{ "digest": "{}",
+                             "mediaType": "application/vnd.oci.image.config.v1+json",
+                             "size": {} }},
                  "layers": [
                     {{
                               "mediaType": "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -76,7 +76,13 @@ mod interface_tests {
             .send()
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Could not get {}:{}",
+            name,
+            tag
+        );
         let mani: manifest::ManifestV2 = resp.json().await.unwrap();
         assert_eq!(mani.schema_version, 2);
     }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -83,8 +83,7 @@ mod interface_tests {
             name,
             tag
         );
-        let mani: manifest::ManifestV2 = resp.json().await.unwrap();
-        assert_eq!(mani.schema_version, 2);
+        let _: manifest::Manifest = resp.json().await.unwrap();
     }
 
     async fn upload_to_nonwritable_repo(cl: &reqwest::Client, name: &str) {

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -155,6 +155,15 @@ mod interface_tests {
         //Need to special case single name repos
         get_manifest(&client, "f/docker/alpine", "latest").await;
 
+        //Download an amd64 manifest, then the multi platform version of the same manifest
+        get_manifest(
+            &client,
+            "f/docker/hello-world",
+            "sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4",
+        )
+        .await;
+        get_manifest(&client, "f/docker/hello-world", "linux").await;
+
         //test writing manifest to proxy dir isn't allowed
         upload_to_nonwritable_repo(&client, "f/failthis").await;
     }


### PR DESCRIPTION
Sorry, I wanted this PR to be smaller but then went down the rabbithole of file integrity and concurrent writes.

- Fixes #310 (Fixes https://github.com/Extrality/trow/issues/1): 
    Relevant changes are in `fn create_accept_header` and `async fn download_manifest_and_layers` + newly created `async fn download_blob`
    We have to download every layer of every platform because a client might ask for any random layer.
- Lots of improvements regarding #309:
    I ended up creating `lib/server/temporary_file.rs`, take a look at `test_temporary_file_async_cancellation` ;)
    Thanks to this wrapper:
    - there are no stale scratch file: either a file exists and is being worked on, or it doesn't exist
    - trow cannot write to a scratch file without being its creator: no concurrent writes
- Concurrent download of multi platform manifests and of layers: the speed increase is noticeable
- I didn't understand why Trow used `fs::copy` to move blobs from the scratch to their destination, so I changed it to `fs::rename` (I think it's fair to assume that both these directories are on the same filesystem), the speed increase is noticeable here too