### PR TITLE
Allow overriding the image tag.

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
       containers:
       - name: trow-pod
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - "--no-tls" 


### PR DESCRIPTION
To allow consumers to modify it if needed.

No worries if you don't want to allow this :-) But we noticed that the charts hadn't been updated as part of the 0.3.5 release and hence noticed that this couldn't be overridden, and it seemed useful as an option :-) Especially as the image itself can be overridden :-) 