### PR TITLE
fix memory usage: use streams to write blobs

### DIFF
--- a/trow-server/Cargo.toml
+++ b/trow-server/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0"
 serde_derive = "^1.0"
 trow-protobuf = { path = "../trow-protobuf" }
 rustc-serialize = "0.3"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "stream"] }
 prometheus = { version = "0.13"}
 lazy_static = "1.4.0"
 fs3 = "0.5.0"

--- a/trow-server/src/server.rs
+++ b/trow-server/src/server.rs
@@ -453,7 +453,7 @@ impl TrowServer {
         } else {
             cl.get(&addr).send().await?
         };
-        file.write_all(&resp.bytes().await?).await?;
+        file.write_stream(resp.bytes_stream()).await?;
         self.save_blob(file.path(), digest)?;
         Ok(())
     }


### PR DESCRIPTION
Fixes #327.

Note:
I'm currently working on https://github.com/ContainerSolutions/trow/tree/multi-proxy-registry, a spiritual successor to https://github.com/ContainerSolutions/trow/pull/250 with the goal to also integrate something like https://github.com/phenixblue/imageswap-webhook so users don't have to edit every image field of every deployment to use Trow.
Are you open to such change @amouat ?