### PR TITLE
Add ability to override securityContext + automountServiceAccountToken

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         {{- include "trow.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -72,6 +73,10 @@ spec:
           mountPath: /etc/trow
           readOnly: true
     {{- end}}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
     {{- if and (.Values.trow.user) (.Values.trow.password) }}
       volumes:
         - name: trow-pass
@@ -81,10 +86,10 @@ spec:
               - key: pass
                 path: pass
     {{- end}}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 333333
-        runAsGroup: 333333
-        fsGroup: 333333
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -69,3 +69,9 @@ volumeClaim:
     requests:
       storage: 20Gi
 
+automountServiceAccountToken: false
+podSecurityContext:
+  runAsUser: 333333
+  runAsGroup: 333333
+  fsGroup: 333333
+containerSecurityContext: {}


### PR DESCRIPTION
We've started using some K8s security scanners and they have suggest that the security posture of pods should be hardened from the defaults.

This allows the pod and container `securityContext` objects as well as the pod `automountServiceAccountToken` field to be modified when using the Helm chart.

Since Trow does not appear to use the Kubernetes API at present, this also sets the `automountServiceAccountToken` to false by default.