### PR TITLE
Allow `--host` to be set through helm

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -29,6 +29,10 @@ spec:
           - "--no-tls" 
           - "-n" 
           - {{ .Values.trow.domain | quote }}
+          {{- if .Values.trow.host }}
+          - "--host"
+          - {{ .Values.trow.host | quote }}
+          {{- end}}
           {{- if and (.Values.trow.user) (.Values.trow.password) }}
           - "-u" 
           - {{ .Values.trow.user | quote }} 

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -10,6 +10,7 @@ image:
 
 trow:
   domain: myregistry.mydomain.io
+  # host: "::" # Enables IPv6 Support, by listening also on IPv6 interfaces
   # user: user
   # password: password
   validation:


### PR DESCRIPTION
This enable optional IPv6 support by allowing trow to be bound to `::` through the helm chart

Related to #333. 

I don't wanted to create a "core change" for that by changing the default value for the CLI arg, as this might also break windows support (depends on how windows handles `::` when binding sockets), or possibly even non-standard Linux configurations.

I tested it successfully in my test cluster and it works.
