### PR TITLE
Fix buildkit export-cache with Trow.

### DIFF
--- a/trow-server/src/manifest.rs
+++ b/trow-server/src/manifest.rs
@@ -43,7 +43,7 @@ pub struct ManifestListEntry {
     pub media_type: String, //TODO: make enum
     pub size: u32,
     pub digest: String,
-    pub platform: Platform,
+    pub platform: Option<Platform>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
We're using Buildkit for building images and pushing them to Trow.

We tried adding the `--export-cache` argument to Buildkit (e.g. `--export-cache type=registry,mode=max,ref=some/image:cache,compression=zstd`) but this fails with a 400 in Trow.

It seems to be due to the fact that there's no `platform` field, afaiu. The error is:

```
ERROR Error verifying manifest Error("missing field `platform`")
```

Making this field optional makes the `--export-cache` argument work for us.

I have no idea about the bigger implications of this - but thought this might be okay (everything seems to continue working for us) :-)